### PR TITLE
if nothing to subscribe, don't call redis conn

### DIFF
--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -107,10 +107,10 @@ class ResultConsumer(BaseResultConsumer):
         metas = [meta for meta in metas if meta]
         for meta in metas:
             self.on_state_change(self._decode_result(meta), None)
-        self._pubsub = self.backend.client.pubsub(
-            ignore_subscribe_messages=True,
-        )
         if self.subscribed_to:
+            self._pubsub = self.backend.client.pubsub(
+                ignore_subscribe_messages=True,
+            )
             self._pubsub.subscribe(*self.subscribed_to)
 
     @contextmanager


### PR DESCRIPTION
fix an error which is introduced by pr7040.  

## Description

Nothing to subscribe so should not  assign to _pubsub ,  then  drain_events  just sleep.    The error   introduced by pr7040 :  `RuntimeError: pubsub connection not set: did you forget to call subscribe() or psubscribe()?`

[discussion](https://github.com/celery/celery/discussions/7212)
